### PR TITLE
Add lobby settings and vote-to-end gameplay

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -7,6 +7,10 @@ const createBtn = document.getElementById('create-btn');
 const nameInput = document.getElementById('name-input');
 const codeInput = document.getElementById('code-input');
 const errorEl = document.getElementById('entry-error');
+const modeFixedRadio = document.getElementById('mode-fixed');
+const modeUnlimitedRadio = document.getElementById('mode-unlimited');
+const questionCountInput = document.getElementById('question-count');
+const fixedConfig = document.getElementById('fixed-config');
 const lobbyCodeEl = document.getElementById('lobby-code');
 const playerListEl = document.getElementById('player-list');
 const questionArea = document.getElementById('question-area');
@@ -15,14 +19,29 @@ const answerForm = document.getElementById('answer-form');
 const answerInput = document.getElementById('answer-input');
 const answerHint = document.getElementById('answer-hint');
 const resultsArea = document.getElementById('results-area');
+const summaryArea = document.getElementById('summary-area');
 const statusArea = document.getElementById('status-area');
 const readyBtn = document.getElementById('ready-btn');
 const leaveBtn = document.getElementById('leave-btn');
+const voteBtn = document.getElementById('end-vote-btn');
 
 let currentLobbyCode = null;
+let currentPlayerId = null;
 let answerSubmitted = false;
 let readySent = false;
 let lastResultsShown = false;
+
+const distanceFormatter = new Intl.NumberFormat('de-DE', {
+  maximumFractionDigits: 2,
+  useGrouping: true
+});
+
+function formatDistance(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+  return distanceFormatter.format(value);
+}
 
 function showEntry() {
   entryScreen.classList.remove('hidden');
@@ -34,9 +53,38 @@ function showLobby() {
   lobbyScreen.classList.remove('hidden');
 }
 
+function updateQuestionModeUI() {
+  const isFixed = modeFixedRadio.checked;
+  if (isFixed) {
+    fixedConfig.classList.remove('hidden');
+    questionCountInput.disabled = false;
+  } else {
+    fixedConfig.classList.add('hidden');
+    questionCountInput.disabled = true;
+  }
+}
+
 async function createLobby() {
   try {
-    const response = await fetch('/lobbies', { method: 'POST' });
+    const mode = modeUnlimitedRadio.checked ? 'unlimited' : 'fixed';
+    let questionCount = null;
+    errorEl.textContent = '';
+
+    if (mode === 'fixed') {
+      const parsed = Number.parseInt(questionCountInput.value, 10);
+      if (Number.isNaN(parsed) || parsed < 1) {
+        errorEl.textContent = 'Bitte gib eine gültige Anzahl an Fragen ein.';
+        return;
+      }
+      questionCount = Math.min(parsed, 99);
+      questionCountInput.value = String(questionCount);
+    }
+
+    const response = await fetch('/lobbies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode, questionCount })
+    });
     const data = await response.json();
     if (data?.code) {
       codeInput.value = data.code;
@@ -73,6 +121,7 @@ function joinLobby() {
     }
 
     currentLobbyCode = code;
+    currentPlayerId = response.playerId || null;
     lobbyCodeEl.textContent = code;
     showLobby();
     answerInput.value = '';
@@ -112,6 +161,8 @@ function resetRoundUI() {
   answerHint.textContent = '';
   resultsArea.innerHTML = '';
   resultsArea.classList.add('hidden');
+  summaryArea.innerHTML = '';
+  summaryArea.classList.add('hidden');
   questionArea.classList.remove('hidden');
   readyBtn.classList.add('hidden');
   readyBtn.disabled = false;
@@ -132,6 +183,8 @@ function displayResults({ answers = [], correctAnswer, type }) {
   questionArea.classList.add('hidden');
   resultsArea.classList.remove('hidden');
   resultsArea.innerHTML = '';
+  summaryArea.classList.add('hidden');
+  summaryArea.innerHTML = '';
 
   if (typeof correctAnswer !== 'undefined' && correctAnswer !== null) {
     const correct = document.createElement('p');
@@ -165,45 +218,167 @@ function displayResults({ answers = [], correctAnswer, type }) {
   readyBtn.classList.remove('hidden');
   readyBtn.disabled = false;
   readyBtn.textContent = 'Bereit für nächste Runde';
-  setStatus('Runde beendet. Klicke auf "Bereit" um fortzufahren.');
   lastResultsShown = true;
+}
+
+function displaySummary(summary) {
+  const data = summary || {};
+  questionArea.classList.add('hidden');
+  resultsArea.classList.add('hidden');
+  readyBtn.classList.add('hidden');
+  summaryArea.classList.remove('hidden');
+  summaryArea.innerHTML = '';
+  voteBtn.classList.add('hidden');
+  answerInput.disabled = true;
+  answerHint.textContent = '';
+  lastResultsShown = true;
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Highscore der Runde';
+  summaryArea.appendChild(heading);
+
+  if (typeof data.roundsPlayed === 'number') {
+    const roundsInfo = document.createElement('p');
+    roundsInfo.className = 'hint';
+    roundsInfo.textContent = `Gespielte Runden: ${data.roundsPlayed}`;
+    summaryArea.appendChild(roundsInfo);
+  }
+
+  if (data.reason) {
+    const reasonText = document.createElement('p');
+    reasonText.className = 'hint';
+    reasonText.textContent =
+      data.reason === 'vote'
+        ? 'Das Spiel wurde per Abstimmung beendet.'
+        : 'Das Spiel endete nach der festgelegten Rundenanzahl.';
+    summaryArea.appendChild(reasonText);
+  }
+
+  if (data.question) {
+    const questionInfo = document.createElement('p');
+    questionInfo.innerHTML = `<strong>Frage:</strong> ${escapeHtml(data.question)}`;
+    summaryArea.appendChild(questionInfo);
+  }
+
+  if (typeof data.correctAnswer !== 'undefined' && data.correctAnswer !== null) {
+    const answerInfo = document.createElement('p');
+    answerInfo.innerHTML = `<strong>Richtige Antwort:</strong> ${escapeHtml(data.correctAnswer)}`;
+    summaryArea.appendChild(answerInfo);
+  }
+
+  if (Array.isArray(data.highscore) && data.highscore.length > 0) {
+    const list = document.createElement('div');
+    list.className = 'results-list';
+
+    data.highscore.forEach((entry, index) => {
+      const row = document.createElement('div');
+      row.className = 'result-entry';
+
+      const name = document.createElement('span');
+      name.innerHTML = `<strong>${index + 1}. ${escapeHtml(entry.name)}</strong>`;
+      row.appendChild(name);
+
+      const details = document.createElement('span');
+      if (entry.distance === null || entry.distance === undefined) {
+        details.textContent = 'Keine gültige Antwort';
+      } else {
+        const answerText = typeof entry.answer === 'undefined' || entry.answer === null ? '–' : entry.answer;
+        const formatted = formatDistance(entry.distance);
+        details.textContent = `${answerText} (Abweichung: ${formatted ?? entry.distance})`;
+      }
+      row.appendChild(details);
+
+      list.appendChild(row);
+    });
+
+    summaryArea.appendChild(list);
+  } else {
+    const empty = document.createElement('p');
+    empty.className = 'hint';
+    empty.textContent = 'Keine gültigen Antworten verfügbar.';
+    summaryArea.appendChild(empty);
+  }
 }
 
 function applyLobbyState(state) {
   if (!state) return;
   renderPlayers(state.players || []);
 
+  const settings = state.settings || {};
+  const endVote = state.endVote || null;
+
+  if (settings.mode === 'unlimited' && state.status !== 'finished') {
+    voteBtn.classList.remove('hidden');
+    const label = endVote ? `Spiel beenden (${endVote.count}/${endVote.required})` : 'Spiel beenden (Abstimmung)';
+    voteBtn.textContent = label;
+    const hasVoted = Array.isArray(endVote?.voterIds) && currentPlayerId ? endVote.voterIds.includes(currentPlayerId) : false;
+    voteBtn.disabled = hasVoted;
+  } else {
+    voteBtn.classList.add('hidden');
+    voteBtn.disabled = false;
+  }
+
+  let statusMessage = null;
+
   if (state.status === 'collecting' && state.currentQuestion) {
     questionText.textContent = state.currentQuestion.question;
     questionArea.classList.remove('hidden');
     resultsArea.classList.add('hidden');
+    summaryArea.classList.add('hidden');
     if (!answerSubmitted) {
       answerInput.disabled = false;
       answerHint.textContent = '';
     }
-    setStatus('Runde läuft – gib deine Antwort ein!');
     readyBtn.classList.add('hidden');
+    statusMessage = 'Runde läuft – gib deine Antwort ein!';
   } else if (state.status === 'waiting') {
     questionArea.classList.add('hidden');
+    resultsArea.classList.add('hidden');
+    summaryArea.classList.add('hidden');
     if (!readySent) {
       readyBtn.classList.remove('hidden');
       readyBtn.disabled = false;
       readyBtn.textContent = 'Bereit zum Start';
     }
-    setStatus('Warte auf den Start der Runde.');
+    statusMessage = 'Warte auf den Start der Runde.';
   } else if (state.status === 'results' && state.lastResults && !lastResultsShown) {
     displayResults(state.lastResults);
+    statusMessage = 'Runde beendet. Klicke auf "Bereit" um fortzufahren.';
+  } else if (state.status === 'finished') {
+    displaySummary(state.finalSummary || null);
+    statusMessage = 'Spiel beendet.';
+  }
+
+  if (endVote && state.status !== 'finished') {
+    const voterNames = Array.isArray(endVote.voterNames) && endVote.voterNames.length > 0 ? ` – ${endVote.voterNames.join(', ')}` : '';
+    const voteMessage = `Stimmen für Spielende: ${endVote.count}/${endVote.required}${voterNames}`;
+    statusMessage = statusMessage ? `${statusMessage} ${voteMessage}` : voteMessage;
+  }
+
+  if (statusMessage !== null) {
+    setStatus(statusMessage);
   }
 }
 
 joinBtn.addEventListener('click', joinLobby);
 createBtn.addEventListener('click', createLobby);
+modeFixedRadio.addEventListener('change', updateQuestionModeUI);
+modeUnlimitedRadio.addEventListener('change', updateQuestionModeUI);
 
 answerForm.addEventListener('submit', event => {
   event.preventDefault();
   if (answerSubmitted) return;
   const answer = answerInput.value.trim();
-  if (!answer) return;
+  if (!answer) {
+    answerHint.textContent = 'Bitte gib eine Zahl ein.';
+    return;
+  }
+  const normalized = answer.replace(',', '.');
+  const numericValue = Number(normalized);
+  if (!Number.isFinite(numericValue)) {
+    answerHint.textContent = 'Bitte gib eine gültige Zahl ein.';
+    return;
+  }
   socket.emit('submitAnswer', answer);
   answerSubmitted = true;
   answerInput.disabled = true;
@@ -220,6 +395,19 @@ readyBtn.addEventListener('click', () => {
 
 leaveBtn.addEventListener('click', () => {
   window.location.reload();
+});
+
+voteBtn.addEventListener('click', () => {
+  if (voteBtn.disabled) return;
+  voteBtn.disabled = true;
+  socket.emit('voteEndGame', response => {
+    if (!response?.success) {
+      voteBtn.disabled = false;
+      if (response?.error) {
+        setStatus(response.error);
+      }
+    }
+  });
 });
 
 socket.on('connect_error', () => {
@@ -248,6 +436,13 @@ socket.on('answerReceived', ({ name }) => {
 
 socket.on('roundResults', payload => {
   displayResults(payload);
+  setStatus('Runde beendet. Klicke auf "Bereit" um fortzufahren.');
 });
 
+socket.on('gameSummary', summary => {
+  displaySummary(summary);
+  setStatus('Spiel beendet.');
+});
+
+updateQuestionModeUI();
 showEntry();

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,34 @@
           <label for="code-input">Lobby-Code</label>
           <input id="code-input" type="text" maxlength="4" placeholder="ABCD" />
         </div>
+        <fieldset class="form-group" id="round-options">
+          <legend>Rundenmodus</legend>
+          <label class="option-row">
+            <input
+              type="radio"
+              name="question-mode"
+              id="mode-fixed"
+              value="fixed"
+              checked
+            />
+            <span>Feste Anzahl von Fragen</span>
+          </label>
+          <div class="option-nested" id="fixed-config">
+            <label for="question-count">Anzahl der Fragen</label>
+            <input
+              id="question-count"
+              type="number"
+              min="1"
+              max="99"
+              step="1"
+              value="5"
+            />
+          </div>
+          <label class="option-row">
+            <input type="radio" name="question-mode" id="mode-unlimited" value="unlimited" />
+            <span>Unbegrenzt – Spielende per Abstimmung</span>
+          </label>
+        </fieldset>
         <div class="actions">
           <button id="join-btn" class="primary">Lobby beitreten</button>
           <button id="create-btn" class="secondary">Neue Lobby erstellen</button>
@@ -36,13 +64,23 @@
         <div id="question-area" class="hidden">
           <p id="question-text"></p>
           <form id="answer-form">
-            <input id="answer-input" type="text" autocomplete="off" required placeholder="Deine Antwort" />
+            <input
+              id="answer-input"
+              type="number"
+              inputmode="decimal"
+              step="any"
+              autocomplete="off"
+              required
+              placeholder="Deine Antwort"
+            />
             <button type="submit" class="primary">Antwort senden</button>
           </form>
           <p id="answer-hint" class="hint"></p>
         </div>
         <div id="results-area" class="hidden"></div>
+        <div id="summary-area" class="hidden"></div>
         <button id="ready-btn" class="primary hidden">Bereit für nächste Runde</button>
+        <button id="end-vote-btn" class="secondary hidden">Spiel beenden (Abstimmung)</button>
       </section>
     </main>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -69,6 +69,38 @@ input:focus {
   border-color: transparent;
 }
 
+fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 14px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+legend {
+  padding: 0 0.35rem;
+  color: #cbd5f5;
+  font-size: 0.95rem;
+}
+
+.option-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.option-row input[type='radio'] {
+  accent-color: #38bdf8;
+}
+
+.option-nested {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding-left: 1.8rem;
+}
+
 button {
   border: none;
   border-radius: 999px;
@@ -164,6 +196,16 @@ button:disabled {
   gap: 0.5rem;
 }
 
+#summary-area {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.results-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
 .result-entry {
   background: rgba(30, 41, 59, 0.6);
   border-radius: 12px;
@@ -218,5 +260,9 @@ button:disabled {
 
   .players {
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+
+  fieldset {
+    padding: 0.75rem;
   }
 }

--- a/questions.json
+++ b/questions.json
@@ -49,12 +49,104 @@
   },
   {
     "id": 9,
-    "question": "Nenne eine bekannte deutsche Märchenfigur.",
-    "type": "text"
+    "question": "Wie viele Minuten hat eine Woche?",
+    "type": "number",
+    "answer": 10080
   },
   {
     "id": 10,
-    "question": "Was ist dein Lieblings-Sommergetränk?",
-    "type": "text"
+    "question": "In welchem Jahr endete der Zweite Weltkrieg?",
+    "type": "number",
+    "answer": 1945
+  },
+  {
+    "id": 11,
+    "question": "Wie viele Meter ist der Mount Everest hoch?",
+    "type": "number",
+    "answer": 8849
+  },
+  {
+    "id": 12,
+    "question": "Wie viele Spieler stehen beim Fußball pro Team auf dem Feld?",
+    "type": "number",
+    "answer": 11
+  },
+  {
+    "id": 13,
+    "question": "Wie viele Tasten hat ein klassisches Klavier?",
+    "type": "number",
+    "answer": 88
+  },
+  {
+    "id": 14,
+    "question": "Wie viele Kilometer beträgt der Umfang der Erde am Äquator?",
+    "type": "number",
+    "answer": 40075
+  },
+  {
+    "id": 15,
+    "question": "Wie viele Bundeskanzler hatte Deutschland seit 1949?",
+    "type": "number",
+    "answer": 9
+  },
+  {
+    "id": 16,
+    "question": "Wie viele Sekunden hat ein Jahr (ohne Schaltjahr)?",
+    "type": "number",
+    "answer": 31536000
+  },
+  {
+    "id": 17,
+    "question": "Wie viele Einwohner hat Berlin (Stand 2023, gerundet auf Tausender)?",
+    "type": "number",
+    "answer": 3660000
+  },
+  {
+    "id": 18,
+    "question": "Wie viele Kilometer misst die Donau?",
+    "type": "number",
+    "answer": 2850
+  },
+  {
+    "id": 19,
+    "question": "Wie viele Zeitzonen hat Russland?",
+    "type": "number",
+    "answer": 11
+  },
+  {
+    "id": 20,
+    "question": "Wie viele Karten hat ein Skatblatt?",
+    "type": "number",
+    "answer": 32
+  },
+  {
+    "id": 21,
+    "question": "Wie viele Kilometer misst die Luftlinie zwischen Berlin und München?",
+    "type": "number",
+    "answer": 505
+  },
+  {
+    "id": 22,
+    "question": "Wie viele Meter ist der Kölner Dom hoch?",
+    "type": "number",
+    "answer": 157
+  },
+  {
+    "id": 23,
+    "question": "Wie viele Inseln gehören zu Schweden (gerundet)?",
+    "type": "number",
+    "answer": 267570
+  },
+  {
+    "id": 24,
+    "question": "Wie viele Tage hat ein Schaltjahr?",
+    "type": "number",
+    "answer": 366
+  },
+  {
+    "id": 25,
+    "question": "Wie viele Einwohner hat die Schweiz (Stand 2023, gerundet auf Tausender)?",
+    "type": "number",
+    "answer": 8700000
   }
 ]


### PR DESCRIPTION
## Summary
- add UI to configure fixed or unlimited rounds when creating a lobby and surface an end-of-game vote button in unlimited sessions
- extend the server to support per-lobby settings, vote-to-end handling, and final round highscore summaries while enforcing numeric answers
- replace the question catalogue with additional numeric-only estimation prompts

## Testing
- npm install
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68d69fea9cc0832cac58285912e1aaac