### PR TITLE
Use workflow run metadata to generate unique image tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,8 +26,9 @@ jobs:
         run: |
           IMAGE_NAME=${GITHUB_REPOSITORY,,}
           echo "image=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          BUILD_VERSION="${BASE_VERSION}-${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          echo "version=${BUILD_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false


### PR DESCRIPTION
## Summary
- include the GitHub Actions run number and attempt in the generated Docker image version so each build publishes a unique tag

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6ad570018832caaaea0d28581d9b6