### PR TITLE
Replace lobby leave text with icon button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -71,7 +71,24 @@
               <span id="lobby-code"></span>
             </span>
             <img src="/logo.png" alt="Näher Draan Logo" class="lobby-logo" />
-            <button id="leave-btn" class="link" type="button">Verlassen</button>
+            <button
+              id="leave-btn"
+              class="link icon-button"
+              type="button"
+              aria-label="Lobby verlassen"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                role="img"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M4.75 4A1.75 1.75 0 0 1 6.5 2.25h6.75A1.75 1.75 0 0 1 15 4v4.25a.75.75 0 0 1-1.5 0V4c0-.138-.112-.25-.25-.25H6.5a.25.25 0 0 0-.25.25v16c0 .138.112.25.25.25h6.75c.138 0 .25-.112.25-.25v-4.25a.75.75 0 0 1 1.5 0V20a1.75 1.75 0 0 1-1.75 1.75H6.5A1.75 1.75 0 0 1 4.75 20V4Zm12.47 6.47a.75.75 0 0 0-1.06 1.06l1.72 1.72H11a.75.75 0 0 0 0 1.5h6.88l-1.72 1.72a.75.75 0 1 0 1.06 1.06l3-3a.75.75 0 0 0 0-1.06l-3-3Z"
+                />
+              </svg>
+              <span class="visually-hidden">Lobby verlassen</span>
+            </button>
           </header>
           <div class="players" id="player-list"></div>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -177,6 +177,20 @@ button.link {
   padding: 0.25rem 0.5rem;
 }
 
+button.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border-radius: 999px;
+}
+
+button.icon-button svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: currentColor;
+}
+
 button:disabled {
   opacity: 0.5;
   cursor: default;


### PR DESCRIPTION
## Summary
- replace the lobby leave text button with an icon-based control and accessible labelling
- add styling for the new icon button variant so the SVG adopts the theme color

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d6b6bac948832c91606a822ba47257