### PR TITLE
Add footer linking to GitHub repository

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -121,6 +121,16 @@
           </button>
         </div>
       </section>
+      <footer class="app-footer">
+        © 2025
+        <a
+          href="https://github.com/derDeno/closer-game"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          derDeno auf GitHub
+        </a>
+      </footer>
     </main>
 
     <script src="/socket.io/socket.io.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -16,6 +16,24 @@ body {
   box-sizing: border-box;
 }
 
+.app-footer {
+  margin-top: clamp(1.5rem, 4vw, 2.5rem);
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.app-footer a {
+  color: #38bdf8;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.app-footer a:focus,
+.app-footer a:hover {
+  text-decoration: underline;
+}
+
 body.round-active {
   align-items: flex-start;
   padding-top: 1rem;


### PR DESCRIPTION
## Summary
- add a footer element with a copyright notice that links to the GitHub repository
- style the new footer to blend with the existing color scheme and provide hover/focus feedback

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6b9ca4764832c8c79cde927edcca1