### PR TITLE
Handle ties when highlighting round results

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -277,7 +277,9 @@ function displayResults({ answers = [], correctAnswer, type }) {
       badge.className = 'badge good';
       badge.textContent = 'Am nächsten dran';
       div.appendChild(badge);
-    } else if (entry.farthest) {
+    }
+
+    if (entry.farthest) {
       const badge = document.createElement('span');
       badge.className = 'badge bad';
       badge.textContent = 'Am weitesten weg';


### PR DESCRIPTION
## Summary
- mark all players tied for the closest or farthest numeric answers during result evaluation
- treat identical answers collectively so everyone shares the correct or incorrect badge
- allow the client to render both closest and farthest indicators when applicable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ebb13290832ca21306b87fa93ca3