### PR TITLE
Add dynamic thousand separators to answer input

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -99,9 +99,8 @@
             <form id="answer-form">
               <input
                 id="answer-input"
-                type="number"
+                type="text"
                 inputmode="decimal"
-                step="any"
                 autocomplete="off"
                 required
                 placeholder="Deine Antwort"

--- a/server.js
+++ b/server.js
@@ -51,9 +51,40 @@ function parseNumericAnswer(value) {
     return Number.isFinite(value) ? value : null;
   }
   if (typeof value === 'string') {
-    const normalized = value.replace(',', '.').trim();
-    if (normalized.length === 0) return null;
-    const parsed = Number(normalized);
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return null;
+
+    let negative = false;
+    let normalized = trimmed;
+
+    if (normalized.startsWith('-')) {
+      negative = true;
+      normalized = normalized.slice(1);
+    } else if (normalized.startsWith('+')) {
+      normalized = normalized.slice(1);
+    }
+
+    normalized = normalized.replace(/\s+/g, '');
+    normalized = normalized.replace(/[^0-9.,]/g, '');
+
+    if (normalized.length === 0) {
+      return null;
+    }
+
+    if (normalized.includes(',')) {
+      normalized = normalized.replace(/\./g, '').replace(',', '.');
+    } else if (/^\d{1,3}(\.\d{3})+$/.test(normalized)) {
+      normalized = normalized.replace(/\./g, '');
+    } else {
+      normalized = normalized.replace(/,/g, '');
+    }
+
+    let result = (negative ? '-' : '') + normalized;
+    if (result.endsWith('.')) {
+      result = result.slice(0, -1);
+    }
+
+    const parsed = Number(result);
     return Number.isFinite(parsed) ? parsed : null;
   }
   return null;


### PR DESCRIPTION
## Summary
- add numeric normalization helpers on the client and apply grouping while typing in the answer field
- send normalized numeric strings when submitting answers and allow formatted input by changing the field to text
- make the server-side parser accept grouped numbers with decimal commas

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68d70fbd0190832cab9827e427dcd8ba